### PR TITLE
Fix #1: Error open terminal due to TERM error

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,7 @@ apps:
     environment:
       LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$LD_LIBRARY_PATH"
       LC_ALL: "C.UTF-8"
+      TERM: "screen-256color"
     command: ncspot
     plugs:
       - network


### PR DESCRIPTION
This bug report has more data points.
https://github.com/hrkfdn/ncspot/issues/139

Notice the less-common TERM values involved: rxvt-256color and st-256color. It also failed for me why trying to use with Alacritty.

For me, explicitly setting the TERM in the environment fixed it:

  alacritty -e env TERM=screen-256color ncspot

My guess is that `ncspot` is running inside a container which does have access to custom "terminfo" entries that exist outside the container.

The fix proposed here is to explictly set a TERM value that appears to work within the `snap` container.