### PR TITLE
Expose pulseaudio plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ apps:
       - network
       - network-bind
       - unity7
-      - audio-playback
+      - pulseaudio
     slots:
       - mpris
 


### PR DESCRIPTION
There have been a few bug reports concerning a lack of audio playback with the snap. I noticed that while ncspot uses pulseaudio by default per its README, the snap does not connect to pulseaudio. This updated yaml was able to produce a fully functional build with audio playback.